### PR TITLE
Bump Lambda function runtime to python 3.11

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -51,7 +51,7 @@ Resources:
       Description: Copy RDS snapshots cross-region
       CodeUri: src/
       Handler: copy-snapshot.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.11
       Role: !GetAtt SnapshotCopyIAMRole.Arn
       Environment:
         Variables:


### PR DESCRIPTION
As the title says.

Tested by deploying this SAM stack in staging and testing the Lambda using the event body in `local-dev/event.json` and substituting the values where appropriate with values found in staging.